### PR TITLE
add support for renaming/moving files

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,7 +71,8 @@ called with a path that has not been created using `create_file` in the current
 transaction it will be opened normally, as if the standard `open` method was
 used.
 
-You can also delete files with `delete_file`.
+You can also delete files with `delete_file` as well as rename or move files
+using `rename_file`.
 
 
 Unit tests

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.txt')).read()
 CHANGES = open(os.path.join(here, 'CHANGES.txt')).read()
 
-version = '2.1'
+version = '2.2dev'
 
 setup(name='repoze.filesafe',
       version=version,

--- a/src/repoze/filesafe/__init__.py
+++ b/src/repoze/filesafe/__init__.py
@@ -13,7 +13,6 @@ def _remove_manager(*a):
     except AttributeError:
         pass
 
-
 def _get_manager(tempdir=None):
     manager = getattr(_local, 'manager', None)
     if manager is not None:
@@ -39,7 +38,6 @@ def rename_file(src, dst):
 def open_file(path, mode='r'):
     mgr = _get_manager()
     return mgr.open_file(path, mode)
-
 
 def delete_file(path):
     mgr = _get_manager()

--- a/src/repoze/filesafe/__init__.py
+++ b/src/repoze/filesafe/__init__.py
@@ -13,6 +13,7 @@ def _remove_manager(*a):
     except AttributeError:
         pass
 
+
 def _get_manager(tempdir=None):
     manager = getattr(_local, 'manager', None)
     if manager is not None:
@@ -30,9 +31,15 @@ def create_file(path, mode='w', tempdir=None):
     return mgr.create_file(path, mode)
 
 
+def rename_file(src, dst):
+    mgr = _get_manager()
+    return mgr.rename_file(src, dst)
+
+
 def open_file(path, mode='r'):
     mgr = _get_manager()
     return mgr.open_file(path, mode)
+
 
 def delete_file(path):
     mgr = _get_manager()

--- a/src/repoze/filesafe/manager.py
+++ b/src/repoze/filesafe/manager.py
@@ -47,7 +47,8 @@ class FileSafeDataManager:
                 del self.vault[dst]
             else:
                 raise ValueError("%s is already taken", dst)
-        self.vault[dst] = dict(tempfile=src, source=src)
+        self.vault[dst] = dict(tempfile=src, source=src,
+            moved=True, has_original=False)
 
     def open_file(self, path, mode="r"):
         if path in self.vault:

--- a/src/repoze/filesafe/manager.py
+++ b/src/repoze/filesafe/manager.py
@@ -41,6 +41,14 @@ class FileSafeDataManager:
         self.vault[path] = dict(tempfile=file.name)
         return file
 
+    def rename_file(self, src, dst):
+        if dst in self.vault:
+            if self.vault[dst].get('deleted', False):
+                del self.vault[dst]
+            else:
+                raise ValueError("%s is already taken", dst)
+        self.vault[dst] = dict(tempfile=src, source=src)
+
     def open_file(self, path, mode="r"):
         if path in self.vault:
             info = self.vault[path]
@@ -126,6 +134,8 @@ class FileSafeDataManager:
                 try:
                     if info["has_original"]:
                         os.rename("%s.filesafe" % target, target)
+                    elif 'source' in info:
+                        os.rename(target, info["source"])
                     else:
                         os.unlink(target)
                 except OSError:

--- a/src/repoze/filesafe/testing.py
+++ b/src/repoze/filesafe/testing.py
@@ -50,6 +50,14 @@ class DummyDataManager:
         self.vault[path] = {'tempfile': tmppath}
         return file
 
+    def rename_file(self, src, dst):
+        if dst in self.vault:
+            if self.vault[dst].get('deleted', False):
+                del self.vault[dst]
+            else:
+                raise ValueError("%s is already taken", dst)
+        self.vault[dst] = dict(tempfile=src, source=src)
+
     def open_file(self, path, mode="r"):
         cls = MockBytesIO if 'b' in mode else MockStringIO
         if path in self.vault:
@@ -125,6 +133,10 @@ class DummyDataManager:
                     if info["has_original"]:
                         oldname = "%s.filesafe" % target
                         self.data[target] = self.data[oldname]
+                        del self.data[oldname]
+                    elif 'source' in info:
+                        oldname = target
+                        self.data[info["source"]] = self.data[oldname]
                         del self.data[oldname]
                     else:
                         del self.data[target]

--- a/src/repoze/filesafe/testing.py
+++ b/src/repoze/filesafe/testing.py
@@ -56,7 +56,8 @@ class DummyDataManager:
                 del self.vault[dst]
             else:
                 raise ValueError("%s is already taken", dst)
-        self.vault[dst] = dict(tempfile=src, source=src)
+        self.vault[dst] = dict(tempfile=src, source=src,
+            moved=True, has_original=False)
 
     def open_file(self, path, mode="r"):
         cls = MockBytesIO if 'b' in mode else MockStringIO

--- a/src/repoze/filesafe/tests.py
+++ b/src/repoze/filesafe/tests.py
@@ -378,47 +378,37 @@ class FileSafeDataManagerTests(unittest.TestCase):
         else:
             self.fail('No OSError exception raised')
 
-
-class FileSafeRenameFileTests(unittest.TestCase):
-
-    def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
-        self.dm = FileSafeDataManager(self.tempdir)
-
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
-
     def test_rename_file(self):
         dm = self.dm
         source = os.path.join(self.tempdir, "foo")
         target = os.path.join(self.tempdir, "bar")
-        with open(source, "w") as fd:
+        with self.open(source, "w") as fd:
             fd.write("...---...")
-        self.assertEqual(os.path.exists(source), True)
-        self.assertEqual(os.path.exists(target), False)
+        self.assertEqual(self.exists(source), True)
+        self.assertEqual(self.exists(target), False)
         dm.rename_file(source, target)
         dm.commit(None)
         dm.tpc_finish(None)
         newfile = dm.open_file(target, "r")
         self.assertEqual(newfile.read(), "...---...")
-        self.assertEqual(os.path.exists(target), True)
-        self.assertEqual(open(target).read(), "...---...")
-        self.assertEqual(os.path.exists(source), False)
+        self.assertEqual(self.exists(target), True)
+        self.assertEqual(self.open(target).read(), "...---...")
+        self.assertEqual(self.exists(source), False)
 
     def test_abort_rename_file(self):
         dm = self.dm
         source = os.path.join(self.tempdir, "foo")
         target = os.path.join(self.tempdir, "bar")
-        with open(source, "w") as fd:
+        with self.open(source, "w") as fd:
             fd.write("...---...")
-        self.assertEqual(os.path.exists(source), True)
-        self.assertEqual(os.path.exists(target), False)
+        self.assertEqual(self.exists(source), True)
+        self.assertEqual(self.exists(target), False)
         dm.rename_file(source, target)
         dm.commit(None)
         dm.tpc_abort(None)
-        self.assertEqual(os.path.exists(target), False)
-        self.assertEqual(os.path.exists(source), True)
-        self.assertEqual(open(source).read(), "...---...")
+        self.assertEqual(self.exists(target), False)
+        self.assertEqual(self.exists(source), True)
+        self.assertEqual(self.open(source).read(), "...---...")
 
 
 class DummyDataManagerTests(FileSafeDataManagerTests):

--- a/src/repoze/filesafe/tests.py
+++ b/src/repoze/filesafe/tests.py
@@ -404,6 +404,20 @@ class FileSafeDataManagerTests(unittest.TestCase):
         self.assertEqual(self.exists(source), True)
         self.assertEqual(self.exists(target), False)
         dm.rename_file(source, target)
+        dm.tpc_abort(None)
+        self.assertEqual(self.exists(target), False)
+        self.assertEqual(self.exists(source), True)
+        self.assertEqual(self.open(source).read(), "...---...")
+
+    def test_abort_rename_file_before_finish(self):
+        dm = self.dm
+        source = os.path.join(self.tempdir, "foo")
+        target = os.path.join(self.tempdir, "bar")
+        with self.open(source, "w") as fd:
+            fd.write("...---...")
+        self.assertEqual(self.exists(source), True)
+        self.assertEqual(self.exists(target), False)
+        dm.rename_file(source, target)
         dm.commit(None)
         dm.tpc_abort(None)
         self.assertEqual(self.exists(target), False)


### PR DESCRIPTION
for now i've created a separate test class as i didn't really grok the reason for the extra `DummyDataManager`.  however, if the patch looks alright (and somebody tells me what the dummy manager is for :)), i'll be happy to add a `rename_file` there as well…