### PR TITLE
allow to request the use of `os.renames` with `rename_file`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@ Changelog
 
 - Add a new ``repoze.filesafe.rename_file`` function to move files.
 
+- Add additional ``recursive`` parameter to allow ``repoze.filesafe.rename_file``
+  to use ``os.renames``, i.e. recursively create/remove intermediate directories.
+
 
 2.1 - (2014-05-06)
 ------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,7 +72,14 @@ transaction it will be opened normally, as if the standard `open` method was
 used.
 
 You can also delete files with `delete_file` as well as rename or move files
-using `rename_file`.
+using `rename_file`. The latter behaves like `os.rename`_, or like
+`os.renames`_, respectively, if you set the additional `recursive` parameter
+to `True`. In this case, intermediate directories will be created as necessary,
+but empty directories in the `src` path will also be deleted after the file
+has been moved successfully.
+
+.. _os.rename: https://docs.python.org/3.4/library/os.html#os.rename
+.. _os.renames: https://docs.python.org/3.4/library/os.html#os.renames
 
 
 Unit tests

--- a/src/repoze/filesafe/__init__.py
+++ b/src/repoze/filesafe/__init__.py
@@ -30,9 +30,9 @@ def create_file(path, mode='w', tempdir=None):
     return mgr.create_file(path, mode)
 
 
-def rename_file(src, dst):
+def rename_file(src, dst, recursive=False):
     mgr = _get_manager()
-    return mgr.rename_file(src, dst)
+    return mgr.rename_file(src, dst, recursive)
 
 
 def open_file(path, mode='r'):

--- a/src/repoze/filesafe/testing.py
+++ b/src/repoze/filesafe/testing.py
@@ -50,14 +50,14 @@ class DummyDataManager:
         self.vault[path] = {'tempfile': tmppath}
         return file
 
-    def rename_file(self, src, dst):
+    def rename_file(self, src, dst, recursive=False):
         if dst in self.vault:
             if self.vault[dst].get('deleted', False):
                 del self.vault[dst]
             else:
                 raise ValueError("%s is already taken", dst)
         self.vault[dst] = dict(tempfile=src, source=src,
-            moved=True, has_original=False)
+            moved=True, has_original=False, recursive=recursive)
 
     def open_file(self, path, mode="r"):
         cls = MockBytesIO if 'b' in mode else MockStringIO

--- a/src/repoze/filesafe/tests.py
+++ b/src/repoze/filesafe/tests.py
@@ -395,7 +395,7 @@ class FileSafeDataManagerTests(unittest.TestCase):
         self.assertEqual(self.open(target).read(), "...---...")
         self.assertEqual(self.exists(source), False)
 
-    def test_rename_file_with_renames(self):
+    def test_recursive_rename_file(self):
         dm = self.dm
         source = os.path.join(self.tempdir, "foo")
         target = os.path.join(self.tempdir, "subdir/bar")
@@ -438,6 +438,22 @@ class FileSafeDataManagerTests(unittest.TestCase):
         dm.commit(None)
         dm.tpc_abort(None)
         self.assertEqual(self.exists(target), False)
+        self.assertEqual(self.exists(source), True)
+        self.assertEqual(self.open(source).read(), "...---...")
+
+    def test_abort_recursive_rename_file_before_finish(self):
+        dm = self.dm
+        source = os.path.join(self.tempdir, "foo")
+        target = os.path.join(self.tempdir, "subdir/bar")
+        with self.open(source, "w") as fd:
+            fd.write("...---...")
+        self.assertEqual(self.exists(source), True)
+        self.assertEqual(self.exists(target), False)
+        dm.rename_file(source, target, recursive=True)
+        dm.commit(None)
+        dm.tpc_abort(None)
+        self.assertEqual(self.exists(target), False)
+        self.assertEqual(self.exists(os.path.dirname(target)), False)
         self.assertEqual(self.exists(source), True)
         self.assertEqual(self.open(source).read(), "...---...")
 

--- a/src/repoze/filesafe/tests.py
+++ b/src/repoze/filesafe/tests.py
@@ -395,6 +395,23 @@ class FileSafeDataManagerTests(unittest.TestCase):
         self.assertEqual(self.open(target).read(), "...---...")
         self.assertEqual(self.exists(source), False)
 
+    def test_rename_file_with_renames(self):
+        dm = self.dm
+        source = os.path.join(self.tempdir, "foo")
+        target = os.path.join(self.tempdir, "subdir/bar")
+        with self.open(source, "w") as fd:
+            fd.write("...---...")
+        self.assertEqual(self.exists(source), True)
+        self.assertEqual(self.exists(target), False)
+        dm.rename_file(source, target, recursive=True)
+        dm.commit(None)
+        dm.tpc_finish(None)
+        newfile = dm.open_file(target, "r")
+        self.assertEqual(newfile.read(), "...---...")
+        self.assertEqual(self.exists(target), True)
+        self.assertEqual(self.open(target).read(), "...---...")
+        self.assertEqual(self.exists(source), False)
+
     def test_abort_rename_file(self):
         dm = self.dm
         source = os.path.join(self.tempdir, "foo")


### PR DESCRIPTION
this adds an option to `rename_file` to allow the use of [os.renames](https://docs.python.org/3.4/library/os.html#os.renames) instead of [os.rename](https://docs.python.org/3.4/library/os.html#os.rename) so intermediate directories are recursively created and removed.